### PR TITLE
feat: delete model object by OpenGraphManagerCap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Sui Move build artifacts
+build/
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Operating system files
+.DS_Store
+Thumbs.db

--- a/contracts/tensorflowsui/Move.lock
+++ b/contracts/tensorflowsui/Move.lock
@@ -35,6 +35,6 @@ published-version = "1"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0xe22e733589fa3c9fe694cc1ccbd53700bc6df36d7d3f10b9a6c50223f2f2f330"
-latest-published-id = "0xe22e733589fa3c9fe694cc1ccbd53700bc6df36d7d3f10b9a6c50223f2f2f330"
+original-published-id = "0xa4b6b35ea2109b304d616de049a75126b79c9d873871bf1cbc9b2e258c2a7660"
+latest-published-id = "0xa4b6b35ea2109b304d616de049a75126b79c9d873871bf1cbc9b2e258c2a7660"
 published-version = "1"

--- a/contracts/tensorflowsui/sources/model/graph.move
+++ b/contracts/tensorflowsui/sources/model/graph.move
@@ -26,13 +26,12 @@ module tensorflowsui::graph {
         bias_tensor: tensor::SignedFixedTensor,    
     }
 
-    public struct SignedFixedGraph has key, store {
-        id : UID,
+    public struct SignedFixedGraph has drop, store {
         layers: vector<SignedFixedLayer>,
     }
 
-    public fun create_signed_graph(ctx: &mut TxContext): SignedFixedGraph {
-        SignedFixedGraph { id: object::new(ctx), layers: vector::empty<SignedFixedLayer>() }
+    public fun create_signed_graph(): SignedFixedGraph {
+        SignedFixedGraph { layers: vector::empty<SignedFixedLayer>() }
     }
 
     public fun get_layer_at(graph: &SignedFixedGraph, idx: u64): &SignedFixedLayer {


### PR DESCRIPTION
* `Model` object is converted to a shared object when it's created, so that anyone can call inference function for that model.
* create `OpenGraphManagerCap` object only one time and it's owned by package publisher.
* `Model` object can be deleted by the manager who ownes `OpenGraphManagerCap`